### PR TITLE
Fix property drawer layout on arrays/lists of EnumBitSets

### DIFF
--- a/Editor/EnumBitSetPropertyDrawer.cs
+++ b/Editor/EnumBitSetPropertyDrawer.cs
@@ -11,8 +11,6 @@ namespace Gilzoide.EnumBitSet.Editor
     public class EnumBitSetPropertyDrawer : PropertyDrawer
     {
         private readonly Vector2 BUTTON_PADDING = new Vector2(4, 0);
-            
-        private bool _isShowingChildren;
         
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
@@ -23,8 +21,8 @@ namespace Gilzoide.EnumBitSet.Editor
             
             float labelHeight = EditorGUI.GetPropertyHeight(SerializedPropertyType.String, label);
             var entryRect = new Rect(position.x, position.y, position.width, labelHeight);
-            _isShowingChildren = EditorGUI.PropertyField(entryRect, property, label); 
-            if (!_isShowingChildren)
+            property.isExpanded = EditorGUI.PropertyField(entryRect, property, label); 
+            if (!property.isExpanded)
             {
                 return;
             }
@@ -57,7 +55,7 @@ namespace Gilzoide.EnumBitSet.Editor
         {
             float height = EditorGUI.GetPropertyHeight(SerializedPropertyType.String, label);
             
-            if (!_isShowingChildren)
+            if (!property.isExpanded)
             {
                 return height;
             }

--- a/Editor/EnumBitSetPropertyDrawer.cs
+++ b/Editor/EnumBitSetPropertyDrawer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
@@ -72,6 +73,10 @@ namespace Gilzoide.EnumBitSet.Editor
             if (propertyType.IsArray)
             {
                 propertyType = propertyType.GetElementType();
+            }
+            else if (typeof(IList).IsAssignableFrom(propertyType))
+            {
+                propertyType = propertyType.GetGenericArguments()[0];
             }
 
             Type[] genericArgs = propertyType.GetGenericArgumentsOfBase(typeof(EnumBitSet<,>));

--- a/Editor/EnumBitSetPropertyDrawer.cs
+++ b/Editor/EnumBitSetPropertyDrawer.cs
@@ -19,9 +19,11 @@ namespace Gilzoide.EnumBitSet.Editor
             string joinedNames = string.Join(" | ", currentEnums);
             label.text += " [" + joinedNames + "]";
             label.tooltip = joinedNames;
+
+            float lineHeight = EditorGUIUtility.singleLineHeight;
+            float space = EditorGUIUtility.standardVerticalSpacing;
             
-            float labelHeight = EditorGUI.GetPropertyHeight(SerializedPropertyType.String, label);
-            var entryRect = new Rect(position.x, position.y, position.width, labelHeight);
+            var entryRect = new Rect(position.x, position.y, position.width, lineHeight);
             property.isExpanded = EditorGUI.PropertyField(entryRect, property, label); 
             if (!property.isExpanded)
             {
@@ -30,7 +32,7 @@ namespace Gilzoide.EnumBitSet.Editor
             
             EditorGUI.indentLevel++;
             // "Select All" | "Unselect All" buttons
-            entryRect.y += entryRect.height;
+            entryRect.y += space + entryRect.height;
             var buttonRect = new Rect(entryRect.position, entryRect.size * new Vector2(0.5f, 1f) - BUTTON_PADDING);
             bool selectAll = GUI.Button(buttonRect, "Select All");
             buttonRect.x += entryRect.width * 0.5f + BUTTON_PADDING.x;
@@ -41,8 +43,7 @@ namespace Gilzoide.EnumBitSet.Editor
                 .Where(entry =>
                 {
                     var content = new GUIContent(entry.name);
-                    entryRect.y += entryRect.height;
-                    entryRect.height = EditorGUI.GetPropertyHeight(SerializedPropertyType.Boolean, content);
+                    entryRect.y += space + entryRect.height;
                     bool hasValue = !unselectAll && (selectAll || currentEnums.Contains(entry.name));
                     return EditorGUI.Toggle(entryRect, content, hasValue);
                 }
@@ -54,17 +55,16 @@ namespace Gilzoide.EnumBitSet.Editor
 
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
         {
-            float height = EditorGUI.GetPropertyHeight(SerializedPropertyType.String, label);
-            
-            if (!property.isExpanded)
-            {
-                return height;
-            }
+            float lineHeight = EditorGUIUtility.singleLineHeight;
+            float space = EditorGUIUtility.standardVerticalSpacing;
 
-            return height
-                + height  // "Select All" | "Unselect All" buttons
-                + GetEnumType().GetEnumNames()
-                    .Sum(name => EditorGUI.GetPropertyHeight(SerializedPropertyType.Boolean, new GUIContent(name)));
+            float height = lineHeight;
+            if (property.isExpanded)
+            {
+                height += space + lineHeight;  // "Select All" | "Unselect All" buttons
+                height += GetEnumType().GetEnumNames().Length * (space + lineHeight);
+            }
+            return height;
         }
 
         private Type GetEnumType()

--- a/Editor/EnumBitSetPropertyDrawer.cs
+++ b/Editor/EnumBitSetPropertyDrawer.cs
@@ -68,7 +68,13 @@ namespace Gilzoide.EnumBitSet.Editor
 
         private Type GetEnumType()
         {
-            Type[] genericArgs = fieldInfo.FieldType.GetGenericArgumentsOfBase(typeof(EnumBitSet<,>));
+            Type propertyType = fieldInfo.FieldType;
+            if (propertyType.IsArray)
+            {
+                propertyType = propertyType.GetElementType();
+            }
+
+            Type[] genericArgs = propertyType.GetGenericArgumentsOfBase(typeof(EnumBitSet<,>));
             if (genericArgs?.Length > 0)
             {
                 return genericArgs[0];


### PR DESCRIPTION
This should fix #1 as well as the layout when using serialized arrays/lists of EnumBitSets.